### PR TITLE
add GHA quarto job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Quarto Publish
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Render site
+        uses: quarto-dev/quarto-actions/render@v2
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Render and Publish
+        uses: quarto-dev/quarto-actions/publish@v2
+        with:
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds two jobs:
- Status checks for PRs: `quarto render` is executed on the CI for PRs that target the main branch
- Render and deploy quarto docs to `gh-pages` branch

We only render on the CI, all code executions must be run locally (`quarto render`) and commited to `_freeze` folder.

Unfortunately, there are major limitations to the this PR as we are on a free plan:
- status check cannot be enforced as we cannot enable branch rules on private repos, but the check will still be shown on PRs
- `gh-pages` will not be deployed as we also cannot enable Pages on private repos

**This PR depends on #37 and should be merged after it (I will update the PR)**